### PR TITLE
Improve Makefile configurability

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -338,3 +338,26 @@ consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
 
+---
+
+Copyright 2019 the fsverity-utils authors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ MANDIR = $(PREFIX)/man
 
 CFLAGS ?= -g -O2
 FULL_WARNINGS = no
+PKG_CONFIG ?= pkg-config
 WITH_X11 ?= yes
 WITH_SDL ?= yes
 
@@ -81,21 +82,21 @@ override CPPFLAGS := -I./src/ -D_GNU_SOURCE=1 \
 LIBS = -lm
 
 ### lua
-override CFLAGS += $(shell pkg-config --cflags lua)
-LIBS += $(shell pkg-config --libs lua)
+override CFLAGS += $(shell "$(PKG_CONFIG)" --cflags lua)
+LIBS += $(shell "$(PKG_CONFIG)" --libs lua)
 
 ### debugger
-override CFLAGS += $(shell pkg-config --cflags readline)
-LIBS += $(shell pkg-config --libs readline)
+override CFLAGS += $(shell "$(PKG_CONFIG)" --cflags readline)
+LIBS += $(shell "$(PKG_CONFIG)" --libs readline)
 
 ### Text UI
-override CFLAGS += $(shell pkg-config --cflags ncursesw) -DNCURSES_WIDECHAR=1
-LIBS += $(shell pkg-config --libs ncursesw)
+override CFLAGS += $(shell "$(PKG_CONFIG)" --cflags ncursesw) -DNCURSES_WIDECHAR=1
+LIBS += $(shell "$(PKG_CONFIG)" --libs ncursesw)
 
 ### X11 UI
 ifeq ($(WITH_X11), yes)
-	X11CFLAGS = $(shell pkg-config --cflags x11 xext) -D_GNU_SOURCE=1
-	X11LIBS = $(shell pkg-config --libs x11 xext)
+	X11CFLAGS = $(shell "$(PKG_CONFIG)" --cflags x11 xext) -D_GNU_SOURCE=1
+	X11LIBS = $(shell "$(PKG_CONFIG)" --libs x11 xext)
 
 	override CFLAGS += $(X11CFLAGS) -DHAS_X11=1
 	LIBS += $(X11LIBS)
@@ -104,8 +105,8 @@ endif
 
 ### SDL UI
 ifeq ($(WITH_SDL), yes)
-	SDLCFLAGS = $(shell pkg-config --cflags SDL_gfx sdl12_compat)
-	SDLLIBS = $(shell pkg-config --libs SDL_gfx sdl12_compat)
+	SDLCFLAGS = $(shell "$(PKG_CONFIG)" --cflags SDL_gfx sdl12_compat)
+	SDLLIBS = $(shell "$(PKG_CONFIG)" --libs SDL_gfx sdl12_compat)
 
 	override CFLAGS += $(SDLCFLAGS) -DHAS_SDL=1
 	LIBS += $(SDLLIBS)

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,6 @@ install: all dist/config.lua
 
 	install -m 755 -d -- $(DESTDIR)$(MANDIR)/man1
 	sed "s|@VERSION@|$(VERSION_MAJOR).$(VERSION_MINOR).$(PATCHLEVEL)|g" dist/x48ng.man.1 > $(DESTDIR)$(MANDIR)/man1/x48ng.1
-	gzip -9  $(DESTDIR)$(MANDIR)/man1/x48ng.1
 
 	install -m 755 -d -- $(DESTDIR)$(DOCDIR)
 	cp -R AUTHORS LICENSE README* doc* romdump/ $(DESTDIR)$(DOCDIR)

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,6 @@ DOTOS = src/emu_serial.o \
 
 MAKEFLAGS +=-j$(NUM_CORES) -l$(NUM_CORES)
 
-CC ?= gcc
-
 WITH_X11 ?= yes
 WITH_SDL ?= yes
 

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ dist/x48ng: $(DOTOS)
 
 # Binaries
 $(TARGETS):
-	$(CC) $^ -o $@ $(CPPFLAGS) $(CFLAGS) $(LIBS)
+	$(CC) $^ -o $@ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(LIBS)
 
 # Cleaning
 clean:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git/
 # The governing license can be found in the LICENSE file or at
 # https://opensource.org/license/MIT.
+TARGETS = dist/mkcard dist/checkrom dist/dump2rom dist/x48ng
 
 PREFIX = /usr
 DOCDIR = $(PREFIX)/doc/x48ng
@@ -55,10 +56,6 @@ EXTRA_WARNING_FLAGS := -Wunused-function \
 endif
 
 override CFLAGS := -std=c11 \
-	-I./src/ -D_GNU_SOURCE=1 \
-	-DVERSION_MAJOR=$(VERSION_MAJOR) \
-	-DVERSION_MINOR=$(VERSION_MINOR) \
-	-DPATCHLEVEL=$(PATCHLEVEL) \
 	-Wall -Wextra -Wpedantic \
 	-Wformat=2 -Wshadow \
 	-Wwrite-strings -Wstrict-prototypes -Wold-style-definition \
@@ -74,6 +71,12 @@ override CFLAGS := -std=c11 \
 	$(call cc-option,-Wno-unknown-warning-option) \
 	$(EXTRA_WARNING_FLAGS) \
 	$(CFLAGS)
+
+override CPPFLAGS := -I./src/ -D_GNU_SOURCE=1 \
+	-DVERSION_MAJOR=$(VERSION_MAJOR) \
+	-DVERSION_MINOR=$(VERSION_MINOR) \
+	-DPATCHLEVEL=$(PATCHLEVEL) \
+	$(CPPFLAGS)
 
 LIBS = -lm
 
@@ -123,27 +126,23 @@ endif
 
 .PHONY: all clean clean-all pretty-code install mrproper
 
-all: dist/mkcard dist/checkrom dist/dump2rom dist/x48ng
-
-# Binaries
-dist/mkcard: src/tools/mkcard.o
-	$(CC) $^ -o $@ $(CFLAGS) $(LIBS)
+all: $(TARGETS)
 
 dist/dump2rom: src/tools/dump2rom.o
-	$(CC) $^ -o $@ $(CFLAGS) $(LIBS)
-
+dist/mkcard: src/tools/mkcard.o
 dist/checkrom: src/tools/checkrom.o src/romio.o
-	$(CC) $^ -o $@ $(CFLAGS) $(LIBS)
-
 dist/x48ng: $(DOTOS)
-	$(CC) $^ -o $@ $(CFLAGS) $(LIBS)
+
+# Binaries
+$(TARGETS):
+	$(CC) $^ -o $@ $(CPPFLAGS) $(CFLAGS) $(LIBS)
 
 # Cleaning
 clean:
 	rm -f src/*.o src/tools/*.o src/*.dep.mk src/tools/*.dep.mk
 
 mrproper: clean
-	rm -f dist/mkcard dist/checkrom dist/dump2rom dist/x48ng
+	rm -f $(TARGETS)
 	make -C dist/ROMs mrproper
 
 clean-all: mrproper

--- a/dist/ROMs/Makefile
+++ b/dist/ROMs/Makefile
@@ -3,7 +3,7 @@
 get-roms: sxrom-a sxrom-b sxrom-c sxrom-d sxrom-e sxrom-j gxrom-l gxrom-m gxrom-p gxrom-r
 
 mrproper:
-	-rm ./sxrom-a ./sxrom-b ./sxrom-c ./sxrom-d ./sxrom-e ./sxrom-j ./gxrom-l ./gxrom-m ./gxrom-p ./gxrom-r
+	rm -f ./sxrom-a ./sxrom-b ./sxrom-c ./sxrom-d ./sxrom-e ./sxrom-j ./gxrom-l ./gxrom-m ./gxrom-p ./gxrom-r
 
 sxrom-a:
 	curl "https://www.hpcalc.org/hp48/pc/emulators/sxrom-a.zip" --output - | funzip > "sxrom-a"


### PR DESCRIPTION
These changes extend the configuration options of the build, which allows Gentoo authors to drop their patches (https://github.com/gentoo/guru/commit/ffc7513c2b97c2368e90243da229048bea0d15cc).

This PR changes the logic by which compiler-specific warnings are applied. From the commit message:
> The cc-option filters out unknown flags which make the compiler error
out.
Note that Clang enables Wunused-command-line-argument by default and
merely emits a warning but incurs no error, when it encounters such a
flag.  GCC on the other hand exits unsuccessfully when it is passed a
flag of the form -Wunknown-warning, but no diagnostic is produced for
-Wno-unknown-warning unless other diagnostics are produced.

As a result, we now may pass unknown flags to the compiler as long as they don't cause the build to crash (by themselves).
On the plus side, this approach allows us not to keep track of which compiler support which flags and we don't rely on the existence of the `gcc` and `clang` binaries anymore.
Its usage is discouraged in favor of their target-prefixed variants for cross-compilation, as they may accidentally compile for the host instead of the target.
The same argument applies for the usage of `pkg-config` vs. a freely configurable `PKG_CONFIG`.