### PR TITLE
Makefile: link against user-configurable Lua version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ MANDIR = $(PREFIX)/man
 
 CFLAGS ?= -g -O2
 FULL_WARNINGS = no
+LUA_VERSION ?= lua
 PKG_CONFIG ?= pkg-config
 WITH_X11 ?= yes
 WITH_SDL ?= yes
@@ -82,8 +83,8 @@ override CPPFLAGS := -I./src/ -D_GNU_SOURCE=1 \
 LIBS = -lm
 
 ### lua
-override CFLAGS += $(shell "$(PKG_CONFIG)" --cflags lua)
-LIBS += $(shell "$(PKG_CONFIG)" --libs lua)
+override CFLAGS += $(shell "$(PKG_CONFIG)" --cflags $(LUA_VERSION))
+LIBS += $(shell "$(PKG_CONFIG)" --libs $(LUA_VERSION))
 
 ### debugger
 override CFLAGS += $(shell "$(PKG_CONFIG)" --cflags readline)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Ncurses front-end is always built-in.
 
 ### Dependencies (see .github/workflows/c-cpp.yml for debian packages names)
 
+- Lua
 - readline
 
 for SDL version:


### PR DESCRIPTION
The user now can specify which Lua version to link against by building with `make LUA_VERSION=<pkg-config Lua package>`.

Since Gentoo users can co-install multiple Lua versions side by side (SLOT), their `dev-lang/lua` package doesn't provide a `lua.pc` pkg-config file but only versioned `luaX.Y.pc` files depending on the package SLOT. This minuscule patch allows their package maintainers to drop one more Makefile patch.
