### PR TITLE
fix cc: error: unrecognized command-line option ‘-fsanitize-trap’

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 ifeq ($(FULL_WARNINGS), yes)
 EXTRA_WARNING_FLAGS := -Wunused-function \
 	-Wredundant-decls \
-	-fsanitize-trap \
+	-fsanitize=thread \
 	$(call cc-option,-Wunused-variable)
 endif
 


### PR DESCRIPTION
This PR resolve the issue #33 on Debian 11 and Ubuntu 22.04 and maybe others