### PR TITLE
fix: map KP_DIVIDE to actual divide key instead of Z

### DIFF
--- a/src/ui4x/src/sdl.c
+++ b/src/ui4x/src/sdl.c
@@ -423,7 +423,7 @@ static int sdlkey_to_hpkey( SDL_Keycode k )
             return UI4X_KEY_MULTIPLY;
         case SDLK_SLASH:
         case SDLK_KP_DIVIDE:
-            return UI4X_KEY_Z;
+            return UI4X_KEY_DIVIDE;
         case SDLK_F5:
         case SDLK_ESCAPE:
             return UI4X_KEY_ON;


### PR DESCRIPTION
On Spanish, Italian, Portuguese and other non-QWERTY layouts the physical ÷ key (and the keypad ÷) is sent by SDL as SDLK_KP_DIVIDE. The original code incorrectly mapped it to the letter Z.